### PR TITLE
Spec: #1 Add auto-accept for generated spec

### DIFF
--- a/openspec/changes/1-add-auto-accept-for-generated-spec/proposal.md
+++ b/openspec/changes/1-add-auto-accept-for-generated-spec/proposal.md
@@ -1,0 +1,13 @@
+## Why
+Generated specs currently require explicit operator acceptance before the workflow can continue. When an operator is unavailable, this creates avoidable blocking and delays.
+
+## What Changes
+- Add a configurable auto-accept option for generated specs.
+- When enabled, generated specs are accepted automatically without requiring operator action.
+- Keep current manual acceptance behavior as the default when auto-accept is not enabled.
+- Record that acceptance was automatic (for auditability and operator visibility).
+
+## Impact
+- Reduces workflow blocking for unattended or off-hours runs.
+- Preserves existing behavior for operators who prefer manual review.
+- Requires clear logging/status signaling so downstream steps can distinguish auto-accepted specs from manually accepted specs.

--- a/openspec/changes/1-add-auto-accept-for-generated-spec/specs/generated-spec-acceptance/spec.md
+++ b/openspec/changes/1-add-auto-accept-for-generated-spec/specs/generated-spec-acceptance/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Configurable auto-accept for generated specs
+The orchestrator MUST support configuration to auto-accept generated specs.
+
+#### Scenario: Auto-accept disabled by default
+- **GIVEN** no auto-accept configuration is provided
+- **WHEN** a generated spec is produced
+- **THEN** the orchestrator MUST require manual acceptance before continuing.
+
+#### Scenario: Auto-accept explicitly enabled
+- **GIVEN** auto-accept for generated specs is enabled in configuration
+- **WHEN** a generated spec is produced
+- **THEN** the orchestrator MUST mark the generated spec as accepted without waiting for operator input
+- **AND** continue the workflow.
+
+### Requirement: Acceptance path visibility
+The orchestrator MUST make the acceptance path visible for generated specs.
+
+#### Scenario: Auto-accepted spec is observable
+- **GIVEN** auto-accept for generated specs is enabled
+- **WHEN** a generated spec is accepted automatically
+- **THEN** the orchestrator MUST emit a visible indicator (for example status or log) that acceptance was automatic.
+
+#### Scenario: Manual acceptance remains observable
+- **GIVEN** auto-accept for generated specs is disabled
+- **WHEN** a generated spec is accepted by an operator
+- **THEN** the orchestrator MUST preserve visibility that acceptance occurred via manual operator action.

--- a/openspec/changes/1-add-auto-accept-for-generated-spec/tasks.md
+++ b/openspec/changes/1-add-auto-accept-for-generated-spec/tasks.md
@@ -1,0 +1,16 @@
+## 1. Configuration
+- [ ] 1.1 Add orchestrator config for generated spec auto-accept (default: disabled).
+- [ ] 1.2 Validate config parsing and fallback behavior when unset.
+
+## 2. Workflow Behavior
+- [ ] 2.1 Update generated-spec acceptance flow to bypass manual wait when auto-accept is enabled.
+- [ ] 2.2 Preserve existing manual acceptance gate when auto-accept is disabled.
+- [ ] 2.3 Ensure downstream phases receive accepted status in both paths.
+
+## 3. Observability
+- [ ] 3.1 Emit status/log entry indicating spec was auto-accepted.
+- [ ] 3.2 Include acceptance mode (manual/auto) in relevant run metadata if available.
+
+## 4. Validation
+- [ ] 4.1 Add/adjust tests for enabled and disabled auto-accept scenarios.
+- [ ] 4.2 Add/adjust regression test to ensure default behavior remains manual acceptance.


### PR DESCRIPTION
Draft OpenSpec change for https://github.com/nightshift-playground/nightshift-playground/issues/1.

Change folder: `openspec/changes/1-add-auto-accept-for-generated-spec`

## Specify summary for #1
- Change: `openspec/changes/1-add-auto-accept-for-generated-spec`
- Open questions: none
- Assumptions: Auto-accept applies specifically to the generated-spec acceptance gate and not to other approval/acceptance gates.; Default behavior must remain backward compatible (manual acceptance required unless explicitly enabled).; Existing status/logging surfaces can be reused to indicate acceptance mode without requiring a new external API.
- Risks: If acceptance mode is not clearly surfaced, operators may misinterpret unattended progression as manual review.; Overly broad configuration scoping could unintentionally auto-accept non-generated-spec approvals if implementation boundaries are unclear.; Downstream components that implicitly assume manual acceptance timing may exhibit ordering or race-related regressions when auto-accept is enabled.
- Validation: passed