### PR TITLE
Spec: #3 Add "Escalated" status to readme

### DIFF
--- a/openspec/changes/3-add-escalated-status-to-readme/proposal.md
+++ b/openspec/changes/3-add-escalated-status-to-readme/proposal.md
@@ -1,0 +1,12 @@
+## Why
+The README does not document an "Escalated" status, which creates ambiguity when operators need to mark issues that require higher-level attention.
+
+## What Changes
+- Add an "Escalated" status entry to the README status list.
+- Define when "Escalated" should be used and how it differs from existing statuses.
+- Keep wording consistent with the current README style.
+
+## Impact
+- Clarifies operational workflow for issue triage.
+- Reduces inconsistent status usage across contributors.
+- No code/runtime impact; documentation-only change.

--- a/openspec/changes/3-add-escalated-status-to-readme/specs/readme-status/spec.md
+++ b/openspec/changes/3-add-escalated-status-to-readme/specs/readme-status/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Escalated Status Is Documented
+The README MUST include an "Escalated" status in the documented issue status list.
+
+#### Scenario: Status list includes Escalated
+- **WHEN** a reader checks the README section describing issue statuses
+- **THEN** they see an "Escalated" status entry
+- **AND** the entry is formatted consistently with other statuses.
+
+### Requirement: Escalated Status Meaning Is Clear
+The README MUST define the purpose of the "Escalated" status so it is distinguishable from other statuses.
+
+#### Scenario: Reader interprets Escalated usage
+- **WHEN** a reader reviews the "Escalated" status description
+- **THEN** they understand it is used for issues requiring higher-level attention or intervention
+- **AND** they can distinguish it from normal in-progress or blocked states.

--- a/openspec/changes/3-add-escalated-status-to-readme/tasks.md
+++ b/openspec/changes/3-add-escalated-status-to-readme/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementation
+- [ ] 1.1 Locate the README section that defines issue statuses.
+- [ ] 1.2 Add an "Escalated" status with a concise definition.
+- [ ] 1.3 Ensure terminology and formatting match existing status entries.
+
+## 2. Validation
+- [ ] 2.1 Review README for clarity and consistency after the update.
+- [ ] 2.2 Confirm no conflicting status definitions remain elsewhere in docs.


### PR DESCRIPTION
Draft OpenSpec change for https://github.com/nightshift-playground/nightshift-playground/issues/3.

Change folder: `openspec/changes/3-add-escalated-status-to-readme`

## Specify summary for #3
- Change: `openspec/changes/3-add-escalated-status-to-readme`
- Open questions: none
- Assumptions: The capability name `readme-status` is acceptable for this documentation change.; The README already contains a status list section where the new status should be added.
- Risks: If existing statuses use specialized internal terminology, the new Escalated definition may need wording tweaks for consistency.
- Validation: passed