### PR TITLE
#6: Add "Escalated" status to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The orchestrator picks the top `Ready` issue from a GitHub Project v2, moves it 
 
 Scheduled pickup is enabled by default when the worker starts, so `Backlog` / `Ready` items can be started or resumed automatically through Temporal.
 
+## Workflow statuses
+
+- `Backlog` — work is captured but not yet ready to start.
+- `Ready` — work is prioritized and available for pickup.
+- `In progress` — work is actively being implemented.
+- `In review` — work is completed and awaiting review.
+- `Escalated` — work was raised for operator attention or intervention.
+
 ## Docs map
 
 - `orchestrator/README.md` — main operator guide: worker startup, config loading, manual intake, and scheduled pickup behavior

--- a/openspec/changes/6-add-escalated-status-to-readme/proposal.md
+++ b/openspec/changes/6-add-escalated-status-to-readme/proposal.md
@@ -1,0 +1,10 @@
+## Why
+The README documents available statuses but is missing `Escalated`, which can mislead contributors and operators about supported workflow states.
+
+## What Changes
+- Add `Escalated` to the README status list.
+- Provide a short definition so readers understand when the status applies.
+
+## Impact
+- Documentation becomes consistent with the workflow terminology.
+- No runtime or API behavior changes.

--- a/openspec/changes/6-add-escalated-status-to-readme/specs/readme-status/spec.md
+++ b/openspec/changes/6-add-escalated-status-to-readme/specs/readme-status/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+### Requirement: README includes Escalated status
+The project README MUST list `Escalated` as a supported status in the workflow/status documentation.
+
+#### Scenario: Status list includes Escalated
+- **GIVEN** a reader checks the README section that enumerates statuses
+- **WHEN** they review the documented status values
+- **THEN** `Escalated` appears as one of the listed statuses
+
+### Requirement: Escalated status is defined
+The README MUST provide a brief explanation of what `Escalated` means.
+
+#### Scenario: Reader interprets Escalated correctly
+- **GIVEN** a reader sees `Escalated` in the README status list
+- **WHEN** they read the accompanying description
+- **THEN** they understand it indicates work was raised for operator attention or intervention

--- a/openspec/changes/6-add-escalated-status-to-readme/tasks.md
+++ b/openspec/changes/6-add-escalated-status-to-readme/tasks.md
@@ -1,0 +1,4 @@
+## 1. Documentation Update
+- [ ] 1.1 Add `Escalated` to the status section in `README.md`.
+- [ ] 1.2 Add a concise description of what `Escalated` means in the workflow.
+- [ ] 1.3 Proofread surrounding status text for consistency and clarity.


### PR DESCRIPTION
Closes https://github.com/nightshift-playground/nightshift-playground/issues/6

> Generated by the Night Shift Implement phase.

## Summary
Added a new `Workflow statuses` section to `README.md`, included `Escalated` in the documented status list, and defined it as work raised for operator attention or intervention. Surrounding status wording was kept consistent and concise.

## Follow-ups
- none