### PR TITLE
Spec: #9 Add agent footer for agent authored messages

### DIFF
--- a/openspec/changes/9-add-agent-footer-for-agent-authored-messages/proposal.md
+++ b/openspec/changes/9-add-agent-footer-for-agent-authored-messages/proposal.md
@@ -1,15 +1,17 @@
 ## Why
-Agent-authored messages are currently indistinguishable from other assistant messages once rendered in the conversation transcript. This limits auditability, reduces operator trust in who produced a message, and makes debugging multi-actor flows harder.
+Agent-authored messages are not clearly distinguishable from other assistant messages in the transcript UI. This reduces provenance, operator trust, and debugging clarity in multi-actor workflows.
 
 ## What Changes
-- Add an explicit footer to every agent-authored message.
-- Footer includes stable agent identity metadata: `displayName` and `role`.
-- Define deterministic fallback text for missing optional metadata.
-- Render the footer consistently across all transcript/message presentation surfaces used by the orchestrator.
-- Do not render the footer for non-agent-authored messages.
+- Add an agent footer to messages authored by `author.type = "agent"`.
+- Footer content format: `<displayName> · <role>`.
+- Apply deterministic fallbacks when metadata is missing:
+- `displayName` fallback: `Agent`
+- `role` fallback: `Unknown role`
+- Render the footer consistently anywhere orchestrator transcript messages are displayed.
+- Do not render this footer for non-agent-authored messages.
 
 ## Impact
-- Improves provenance and operator clarity for generated output.
-- Introduces a small UI/layout change for agent-authored messages.
-- Requires updates to message view-model plumbing where agent metadata is shaped for rendering.
-- Requires tests for rendering logic, author-type gating, and fallback behavior.
+- Improves traceability and operator confidence in message provenance.
+- Introduces a small, intentional UI metadata addition on agent-authored messages.
+- Requires view-model plumbing updates for author metadata and fallback resolution.
+- Requires unit and transcript-surface regression coverage for gating and fallback behavior.

--- a/openspec/changes/9-add-agent-footer-for-agent-authored-messages/proposal.md
+++ b/openspec/changes/9-add-agent-footer-for-agent-authored-messages/proposal.md
@@ -1,0 +1,15 @@
+## Why
+Agent-authored messages are currently indistinguishable from other assistant messages once rendered in the conversation transcript. This limits auditability, reduces operator trust in who produced a message, and makes debugging multi-actor flows harder.
+
+## What Changes
+- Add an explicit footer to every agent-authored message.
+- Footer includes stable agent identity metadata: `displayName` and `role`.
+- Define deterministic fallback text for missing optional metadata.
+- Render the footer consistently across all transcript/message presentation surfaces used by the orchestrator.
+- Do not render the footer for non-agent-authored messages.
+
+## Impact
+- Improves provenance and operator clarity for generated output.
+- Introduces a small UI/layout change for agent-authored messages.
+- Requires updates to message view-model plumbing where agent metadata is shaped for rendering.
+- Requires tests for rendering logic, author-type gating, and fallback behavior.

--- a/openspec/changes/9-add-agent-footer-for-agent-authored-messages/specs/agent-message-footer/spec.md
+++ b/openspec/changes/9-add-agent-footer-for-agent-authored-messages/specs/agent-message-footer/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Agent-authored messages include a footer
+The system SHALL render a footer on messages authored by an agent.
+
+#### Scenario: Render footer for agent-authored message
+- **Given** a message whose `author.type` is `agent`
+- **When** the message is rendered in the transcript
+- **Then** a footer is displayed beneath the message body
+- **And** the footer includes the agent display name
+- **And** the footer includes the agent role
+
+### Requirement: Non-agent messages do not include an agent footer
+The system SHALL NOT render the agent footer for messages not authored by an agent.
+
+#### Scenario: No footer for user-authored message
+- **Given** a message whose `author.type` is `user`
+- **When** the message is rendered in the transcript
+- **Then** no agent footer is displayed
+
+#### Scenario: No footer for system-authored message
+- **Given** a message whose `author.type` is `system`
+- **When** the message is rendered in the transcript
+- **Then** no agent footer is displayed
+
+### Requirement: Footer rendering is resilient to partial metadata
+The system SHALL render safely when optional agent metadata is absent.
+
+#### Scenario: Missing optional agent role
+- **Given** a message authored by an agent with a display name but no role
+- **When** the message is rendered
+- **Then** a footer is still displayed
+- **And** the role text is `Unknown role`
+
+#### Scenario: Missing optional agent display name
+- **Given** a message authored by an agent with a role but no display name
+- **When** the message is rendered
+- **Then** a footer is still displayed
+- **And** the display name text is `Agent`
+
+#### Scenario: Missing both optional fields
+- **Given** a message authored by an agent with neither display name nor role
+- **When** the message is rendered
+- **Then** a footer is still displayed
+- **And** the footer text is `Agent · Unknown role`

--- a/openspec/changes/9-add-agent-footer-for-agent-authored-messages/specs/agent-message-footer/spec.md
+++ b/openspec/changes/9-add-agent-footer-for-agent-authored-messages/specs/agent-message-footer/spec.md
@@ -1,45 +1,55 @@
 ## ADDED Requirements
 
 ### Requirement: Agent-authored messages include a footer
-The system SHALL render a footer on messages authored by an agent.
+The system SHALL render a footer for messages authored by an agent.
 
 #### Scenario: Render footer for agent-authored message
-- **Given** a message whose `author.type` is `agent`
-- **When** the message is rendered in the transcript
-- **Then** a footer is displayed beneath the message body
-- **And** the footer includes the agent display name
-- **And** the footer includes the agent role
+- **Given** a message with `author.type` equal to `agent`
+- **When** the message is rendered in a transcript surface
+- **Then** a footer is shown beneath the message body
+- **And** the footer contains the resolved display name
+- **And** the footer contains the resolved role
 
-### Requirement: Non-agent messages do not include an agent footer
+### Requirement: Agent footer format is deterministic
+The system SHALL render the footer text in the format `<displayName> · <role>`.
+
+#### Scenario: Footer uses display name and role
+- **Given** an agent-authored message with `author.displayName = "Runner"` and `author.role = "Implementer"`
+- **When** the message is rendered
+- **Then** the footer text is `Runner · Implementer`
+
+### Requirement: Footer rendering is resilient to missing metadata
+The system SHALL apply deterministic fallback text when optional agent metadata is absent.
+
+#### Scenario: Missing role
+- **Given** an agent-authored message with `author.displayName = "Runner"` and missing `author.role`
+- **When** the message is rendered
+- **Then** the footer text is `Runner · Unknown role`
+
+#### Scenario: Missing display name
+- **Given** an agent-authored message with missing `author.displayName` and `author.role = "Implementer"`
+- **When** the message is rendered
+- **Then** the footer text is `Agent · Implementer`
+
+#### Scenario: Missing both display name and role
+- **Given** an agent-authored message with missing `author.displayName` and missing `author.role`
+- **When** the message is rendered
+- **Then** the footer text is `Agent · Unknown role`
+
+### Requirement: Non-agent-authored messages do not include an agent footer
 The system SHALL NOT render the agent footer for messages not authored by an agent.
 
-#### Scenario: No footer for user-authored message
-- **Given** a message whose `author.type` is `user`
-- **When** the message is rendered in the transcript
-- **Then** no agent footer is displayed
-
-#### Scenario: No footer for system-authored message
-- **Given** a message whose `author.type` is `system`
-- **When** the message is rendered in the transcript
-- **Then** no agent footer is displayed
-
-### Requirement: Footer rendering is resilient to partial metadata
-The system SHALL render safely when optional agent metadata is absent.
-
-#### Scenario: Missing optional agent role
-- **Given** a message authored by an agent with a display name but no role
+#### Scenario: User-authored message
+- **Given** a message with `author.type` equal to `user`
 - **When** the message is rendered
-- **Then** a footer is still displayed
-- **And** the role text is `Unknown role`
+- **Then** no agent footer is shown
 
-#### Scenario: Missing optional agent display name
-- **Given** a message authored by an agent with a role but no display name
+#### Scenario: System-authored message
+- **Given** a message with `author.type` equal to `system`
 - **When** the message is rendered
-- **Then** a footer is still displayed
-- **And** the display name text is `Agent`
+- **Then** no agent footer is shown
 
-#### Scenario: Missing both optional fields
-- **Given** a message authored by an agent with neither display name nor role
+#### Scenario: Assistant-authored non-agent message
+- **Given** a message with `author.type` not equal to `agent`
 - **When** the message is rendered
-- **Then** a footer is still displayed
-- **And** the footer text is `Agent · Unknown role`
+- **Then** no agent footer is shown

--- a/openspec/changes/9-add-agent-footer-for-agent-authored-messages/tasks.md
+++ b/openspec/changes/9-add-agent-footer-for-agent-authored-messages/tasks.md
@@ -1,21 +1,22 @@
-## 1. Author Metadata Plumbing
-- [ ] Identify the canonical message author source in orchestrator message models.
-- [ ] Ensure transcript/render view models include `author.type`, `author.displayName`, and optional `author.role` for agent-authored messages.
-- [ ] Add fallback derivation in view-model mapping:
-- [ ] Missing `displayName` -> `Agent`
-- [ ] Missing `role` -> `Unknown role`
+## 1. Message Author Data
+- [ ] Locate canonical message author source used by transcript rendering.
+- [ ] Ensure message view model exposes `author.type`, `author.displayName`, and `author.role`.
+- [ ] Implement fallback resolution in mapping layer:
+- [ ] `displayName` => `Agent` when empty or missing.
+- [ ] `role` => `Unknown role` when empty or missing.
 
-## 2. Footer Rendering
-- [ ] Add footer rendering for messages where `author.type === "agent"`.
-- [ ] Footer format: `<displayName> · <role>` using resolved fallback values.
-- [ ] Keep footer styling consistent with existing message metadata/secondary text patterns.
-- [ ] Ensure non-agent messages never render the agent footer.
+## 2. Footer UI
+- [ ] Render agent footer only when `author.type === "agent"`.
+- [ ] Use resolved text format: `<displayName> · <role>`.
+- [ ] Keep styling aligned with existing secondary/meta text patterns.
+- [ ] Verify non-agent messages never render the footer.
 
-## 3. Validation
-- [ ] Add/extend unit tests for:
-- [ ] agent-authored message renders footer with explicit metadata.
-- [ ] agent-authored message renders footer with missing role fallback.
-- [ ] agent-authored message renders footer with missing displayName fallback.
-- [ ] non-agent-authored messages do not render footer.
-- [ ] Add/extend integration/snapshot tests for transcript surfaces that render messages.
-- [ ] Run relevant test suites and verify pass.
+## 3. Verification
+- [ ] Add unit tests for:
+- [ ] Agent message with explicit metadata.
+- [ ] Agent message with missing `role` fallback.
+- [ ] Agent message with missing `displayName` fallback.
+- [ ] Agent message with both fields missing (`Agent · Unknown role`).
+- [ ] Non-agent messages (user/system/assistant) do not show footer.
+- [ ] Add or update transcript-level integration/snapshot coverage on affected surfaces.
+- [ ] Run relevant test suites and confirm all pass.

--- a/openspec/changes/9-add-agent-footer-for-agent-authored-messages/tasks.md
+++ b/openspec/changes/9-add-agent-footer-for-agent-authored-messages/tasks.md
@@ -1,0 +1,21 @@
+## 1. Author Metadata Plumbing
+- [ ] Identify the canonical message author source in orchestrator message models.
+- [ ] Ensure transcript/render view models include `author.type`, `author.displayName`, and optional `author.role` for agent-authored messages.
+- [ ] Add fallback derivation in view-model mapping:
+- [ ] Missing `displayName` -> `Agent`
+- [ ] Missing `role` -> `Unknown role`
+
+## 2. Footer Rendering
+- [ ] Add footer rendering for messages where `author.type === "agent"`.
+- [ ] Footer format: `<displayName> · <role>` using resolved fallback values.
+- [ ] Keep footer styling consistent with existing message metadata/secondary text patterns.
+- [ ] Ensure non-agent messages never render the agent footer.
+
+## 3. Validation
+- [ ] Add/extend unit tests for:
+- [ ] agent-authored message renders footer with explicit metadata.
+- [ ] agent-authored message renders footer with missing role fallback.
+- [ ] agent-authored message renders footer with missing displayName fallback.
+- [ ] non-agent-authored messages do not render footer.
+- [ ] Add/extend integration/snapshot tests for transcript surfaces that render messages.
+- [ ] Run relevant test suites and verify pass.


### PR DESCRIPTION
Draft OpenSpec change for https://github.com/nightshift-playground/nightshift-playground/issues/9.

Change folder: `openspec/changes/9-add-agent-footer-for-agent-authored-messages`

## Specify summary for #9
- Change: `openspec/changes/9-add-agent-footer-for-agent-authored-messages`
- Open questions: none
- Assumptions: `author.role` is optional metadata and may be absent in existing message payloads.; Fallbacks are applied at render/view-model time rather than mutating persisted message records.; All transcript/message presentation surfaces share or can reuse a common author-to-footer formatting path.
- Risks: Inconsistent footer behavior if some transcript surfaces bypass shared view-model mapping.; Snapshot tests may require broad updates if multiple surfaces render messages differently.; If upstream message schemas use different author-type enums, gating may miss valid agent messages without normalization.
- Validation: passed